### PR TITLE
Update scalapb version to 0.99.15 to remove python dependency

### DIFF
--- a/project/scalapb.sbt
+++ b/project/scalapb.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.15")
 
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.6"


### PR DESCRIPTION
Compile fails when python is not installed. It also fails if "python" links to python 3.x, it requires 2.7 to work.
Upgrading from 0.99.12 to 0.99.15 removes the issue as python is not required anymore.

Source: https://github.com/scalapb/ScalaPB/issues/268#issuecomment-366575121