### PR TITLE
Updated the protobuf dependencies, which should fix issues on Windows.

### DIFF
--- a/project/scalapb.sbt
+++ b/project/scalapb.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.15")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18")
 
-libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.6"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"


### PR DESCRIPTION
I received a bug report from a windows user, who said:

> I did some research on this and from this URL : https://github.com/scalapb/ScalaPB/issues/268  the recommendation is to “update sbt-protoc to 0.99.18 and ScalaPB to 0.7.0? “

This PR updates those dependencies. I tested on OSX. I'll attempt to test on Windows in VMWare, but it may not work.